### PR TITLE
Fixed bug in json serialize code for updating episim

### DIFF
--- a/Assets/Editor/EpisemeClientTest.cs
+++ b/Assets/Editor/EpisemeClientTest.cs
@@ -1,4 +1,5 @@
-﻿using Episteme;
+﻿using System.Linq;
+using Episteme;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ public class EpisemeClientTest : MonoBehaviour
 		Concept yesG = new Concept("POSACK", ConceptType.ACTION, ConceptMode.G);
 		Concept noL = new Concept("negack", ConceptType.ACTION, ConceptMode.L);
 		Concept noG = new Concept("NEGACK", ConceptType.ACTION, ConceptMode.G);
-		
+
 		// add concepts to the epistemic model
 		model.AddConcept(yesL);
 		model.AddConcept(yesG);
@@ -25,7 +26,7 @@ public class EpisemeClientTest : MonoBehaviour
 		// add relations between them, third boolean param is bidirectional
 		model.AddRelation(yesG, yesL, true);
 		model.AddRelation(noG, noL, true);
-		
+
 		// now add more concepts (objects)
 		Concept redBlock = new Concept("RED", ConceptType.OBJECT, ConceptMode.L);
 		Concept blueBlock = new Concept("BLUE", ConceptType.OBJECT, ConceptMode.L);
@@ -33,11 +34,49 @@ public class EpisemeClientTest : MonoBehaviour
 		model.AddConcept(redBlock);
 		model.AddConcept(blueBlock);
 		model.AddConcept(greenBlock);
-			
+
+		model.SetEpisimUrl("http://localhost:5000");
+	}
+
+	private void second_mock()
+	{
+		model = new EpistemicState();
+		// creating Concept instances (actions)
+		// available types: ACTION, OBJECT, PROPERTY
+		// available modes: L, G
+		Concept pushG = new Concept("push", ConceptType.ACTION, ConceptMode.G);
+		Concept rightL = new Concept("RIGHT", ConceptType.PROPERTY, ConceptMode.L);
+		model.AddConcept(pushG);
+		model.AddConcept(rightL);
+
+		// now add more concepts (objects)
+
 		model.SetEpisimUrl("http://localhost:5000");
 	}
 
 	[Test]
+	public void TestUpdate2()
+	{
+		second_mock();
+		model.InitiateEpisim();
+		var json = Jsonifier.JsonifyEpistemicState(model);
+		Debug.Log(json);
+		
+		var conceptG = model.GetConcept ("push", ConceptType.ACTION, ConceptMode.G);
+		Debug.Log(conceptG);
+		var conceptL = model.GetConcept ("RIGHT", ConceptType.PROPERTY, ConceptMode.L);
+		Debug.Log(conceptL);
+		if (conceptG.Certainty < 0.5 || conceptL.Certainty < 0.5)
+		{
+			conceptG.Certainty = 0.5;
+			conceptL.Certainty = 0.5;
+            json = Jsonifier.JsonifyUpdates(model, new[] {conceptG, conceptL}, new Relation[] {});
+            Debug.Log(json);
+			model.UpdateEpisim(new[] {conceptG, conceptL}, new Relation[] { });
+		}
+	}
+
+    [Test]
 	public void TestInit()
 	{
 		mock();

--- a/Assets/Scripts/Episteme/Concept.cs
+++ b/Assets/Scripts/Episteme/Concept.cs
@@ -83,5 +83,9 @@ namespace Episteme
 			}
 		}
 
+		public override string ToString()
+		{
+			return _type + "::" + _name + "::" + _mode + "::" + _certainty;
+		}
 	}
 }

--- a/Assets/Scripts/Episteme/Jsonifier.cs
+++ b/Assets/Scripts/Episteme/Jsonifier.cs
@@ -63,15 +63,20 @@ namespace Episteme
 		public static string JsonifyUpdatedConcepts(EpistemicState state, params Concept[] concepts)
 		{
 			if (concepts.Length <= 0) return "[]";
-			var collection = state.GetConcepts(concepts[0].Type);
-			return string.Format("[{0}]", string.Join(", ", concepts.Select(concept =>
-				string.Format("\"{0}-{1}-{2}{4}{3:0.00}\"",
-					(int)concept.Type,
-					(int)concept.Mode,
-					collection.GetIndex(concept),
-					concept.Certainty,
-					CertaintySep
-				)).ToArray()));
+			var updatedConceptIndices = new string[concepts.Length];
+			for (int i = 0; i < concepts.Length; i++)
+			{
+				var concept = concepts[i];
+                var collection = state.GetConcepts(concept.Type);
+				updatedConceptIndices[i] = 
+					string.Format("\"{0}-{1}-{2}{4}{3:0.00}\"",
+						(int)concept.Type,
+						(int)concept.Mode,
+						collection.GetIndex(concept),
+						concept.Certainty,
+						CertaintySep);
+			}
+			return string.Format("[{0}]", string.Join(", ", updatedConceptIndices));
 		}
 		
 		public static string JsonifyUpdatedRelations(EpistemicState state, params Relation[] relations)


### PR DESCRIPTION
* When an array of mixed concept types are passed for the update, only some of them are included in the json